### PR TITLE
Merge patch-2 into patch-1

### DIFF
--- a/src/StickySidebar.js
+++ b/src/StickySidebar.js
@@ -1,23 +1,34 @@
 //aside selector
-const aside = document.querySelector('[data-sticky="true"]'), 
+const aside = document.querySelector('[data-sticky="true"]'),
+
 //varibles
-startScroll = 0;
-var endScroll = window.innerHeight - aside.offsetHeight -500,
+startScroll = parseInt(aside.getAttribute('data-top-gap')),
+bottomGap = parseInt(aside.getAttribute('data-bottom-gap'));
+var endScroll = window.innerHeight - aside.offsetHeight - 500,
 currPos = window.scrollY,
 screenHeight = window.innerHeight,
 asideHeight = aside.offsetHeight;
 aside.style.top = startScroll + 'px';
-//check height screen and aside on resize
+
+//check heights of the viewport and the aside on window resize and reapply positioning
 window.addEventListener('resize', ()=>{
     screenHeight = window.innerHeight;
     asideHeight = aside.offsetHeight;
+    position_sticky_sidebar();
 });
+
+document.addEventListener('scroll', position_sticky_sidebar, {
+    capture: true,
+    passive: true
+});
+
 //main function
-document.addEventListener('scroll', () => {
-    endScroll = window.innerHeight - aside.offsetHeight;
+function position_sticky_sidebar() {
+    endScroll = window.innerHeight - aside.offsetHeight - bottomGap;
     let asideTop = parseInt(aside.style.top.replace('px;', ''));
-    if(asideHeight>screenHeight){
+    if (asideHeight>screenHeight) {
         if (window.scrollY < currPos) {
+
             //scroll up
             if (asideTop < startScroll) {
                 aside.style.top = (asideTop + currPos - window.scrollY) + 'px';
@@ -25,6 +36,7 @@ document.addEventListener('scroll', () => {
                 aside.style.top = startScroll + 'px';
             }
         } else {
+
             //scroll down
             if (asideTop > endScroll) {
                 aside.style.top = (asideTop + currPos - window.scrollY) + 'px';
@@ -32,11 +44,8 @@ document.addEventListener('scroll', () => {
                 aside.style.top = endScroll + 'px';
             }
         }
-    }else{
+    } else {
         aside.style.top = startScroll + 'px';
     }
     currPos = window.scrollY;
-}, {
-    capture: true,
-    passive: true
-});
+}


### PR DESCRIPTION
Enable user to set a gap between top/bottom of viewport and top/bottom of sidebar
Reposition the sidebar when viewport resizes preventing a unintentionally partially hidden or badly positioned sidebar